### PR TITLE
Fixes for two critical bugs in KOfam annotation step

### DIFF
--- a/microbeannotator/pipeline/hmmsearch.py
+++ b/microbeannotator/pipeline/hmmsearch.py
@@ -65,20 +65,16 @@ def hmmer_filter(
     hmmsearch_result: List[hmmer.tbl.TBLRow]) -> List[hmmer.tbl.TBLRow]:
     # Initialize list with filtered results
     hmmsearch_result_filt = []
-    # Get model name, threshold and score_type
-    model_name = hmmsearch_result[0].query.name
-    threshold = hmm_model_info[model_name].threshold
-    score_type = hmm_model_info[model_name].score_type
-    if score_type == 'full':
-        for result in hmmsearch_result:
-            if float(result.full_sequence.score) >= threshold:
-                hmmsearch_result_filt.append(result)
-    elif score_type == 'domain':
-        for result in hmmsearch_result:
-            if float(result.best_1_domain.score) >= threshold:
-                hmmsearch_result_filt.append(result)
-    else:
-        for result in hmmsearch_result:
+    for result in hmmsearch_result:
+        # Get model name, threshold and score_type
+        model_name = result.query.name
+        threshold = hmm_model_info[model_name].threshold
+        score_type = hmm_model_info[model_name].score_type
+        if score_type == 'full' and float(result.full_sequence.score) >= threshold:
+            hmmsearch_result_filt.append(result)
+        elif score_type == 'domain' and float(result.best_1_domain.score) >= threshold:
+            hmmsearch_result_filt.append(result)
+        else:
             hmmsearch_result_filt.append(result)
 
     return hmmsearch_result_filt

--- a/microbeannotator/pipeline/hmmsearch.py
+++ b/microbeannotator/pipeline/hmmsearch.py
@@ -137,10 +137,10 @@ def best_match_selector(raw_results: Path) -> Path:
             else:
                 record = line.strip().split('\t')
                 if record[0] not in best_matches:
-                    best_matches[record[0]] = [record[6], line]
+                    best_matches[record[0]] = [float(record[6]), line]
                 else:
-                    if record[6] > best_matches[record[0]][0]:
-                        best_matches[record[0]] = [record[6], line]
+                    if float(record[6]) > best_matches[record[0]][0]:
+                        best_matches[record[0]] = [float(record[6]), line]
         for record in best_matches.values():
             output.write(record[1])
     return outfile

--- a/microbeannotator/pipeline/hmmsearch.py
+++ b/microbeannotator/pipeline/hmmsearch.py
@@ -70,10 +70,12 @@ def hmmer_filter(
         model_name = result.query.name
         threshold = hmm_model_info[model_name].threshold
         score_type = hmm_model_info[model_name].score_type
-        if score_type == 'full' and float(result.full_sequence.score) >= threshold:
-            hmmsearch_result_filt.append(result)
-        elif score_type == 'domain' and float(result.best_1_domain.score) >= threshold:
-            hmmsearch_result_filt.append(result)
+        if score_type == 'full':
+            if float(result.full_sequence.score) >= threshold:
+                hmmsearch_result_filt.append(result)
+        elif score_type == 'domain':
+            if float(result.best_1_domain.score) >= threshold:
+                hmmsearch_result_filt.append(result)
         else:
             hmmsearch_result_filt.append(result)
 


### PR DESCRIPTION
This PR addresses the bugs described in issue #94.

To ensure the correct bit score threshold is used for distinguishing between strong and weak hits in the `hmmer_filter()` function, we've moved the code for obtaining the current model's threshold to within the loop that iterates over each hit from the HMMER results. To ensure that a numerical comparison is used to identify the best match to a given gene in the `best_match_selector()` function, we've added explicit float conversions to the bit scores loaded from the intermediate file of HMM hits.

To confirm that these fixes resolve the bugs, we ran the code from this branch on our test genome from issue #94, _Bradyrhizobium manausense_ BR3351 (NCBI RefSeq GCF_001440035.1). We analyzed the results with the scripts (also provided in issue #94) that count the number of false positives (from bug 1) and incorrect 'best matches' (from bug 2), respectively. In both cases, the number of errors with the fixed code was 0.